### PR TITLE
Normaliza status pending no agendador de jobs

### DIFF
--- a/logline_discovery/Cargo.toml
+++ b/logline_discovery/Cargo.toml
@@ -35,7 +35,7 @@ rayon = "1.7"
 tracing = "0.1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres", "uuid", "json", "chrono"] }
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "env"] }
 dotenvy = "0.15"
 uuid = { version = "1", features = ["serde", "v4"] }
 md5 = "0.7"

--- a/logline_discovery/crates/common/src/job.rs
+++ b/logline_discovery/crates/common/src/job.rs
@@ -5,6 +5,7 @@ use uuid::Uuid;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
 #[sqlx(type_name = "job_status", rename_all = "lowercase")]
 pub enum JobStatus {
+    Pending,
     Queued,
     Running,
     Completed,
@@ -42,7 +43,7 @@ impl Job {
         Self {
             id: Uuid::new_v4(),
             name,
-            status: JobStatus::Queued,
+            status: JobStatus::Pending,
             priority,
             payload,
             created_at: Utc::now(),
@@ -56,7 +57,7 @@ impl Job {
     }
 
     pub fn can_retry(&self) -> bool {
-        self.retry_count < self.max_retries && matches!(self.status, JobStatus::Failed)
+        self.retry_count < self.max_retries
     }
 }
 

--- a/logline_discovery/db/migrations/002_add_pending_job_status.sql
+++ b/logline_discovery/db/migrations/002_add_pending_job_status.sql
@@ -1,0 +1,4 @@
+-- Adds the 'pending' job status for two-phase scheduling and updates defaults.
+ALTER TYPE job_status ADD VALUE IF NOT EXISTS 'pending';
+
+ALTER TABLE jobs ALTER COLUMN status SET DEFAULT 'pending';


### PR DESCRIPTION
## Resumo
- adiciona o status `Pending` ao domínio compartilhado e define-o como padrão de novos jobs
- reescreve o scheduler para promover jobs pendentes, resetar stuck e notificar workers sem macros dependentes de banco
- atualiza o worker para registrar execuções com IDs próprios, reencaminhar falhas para `pending` e acumular métricas
- habilita suporte `clap` com `env` e cria migração SQL para incluir o novo status no tipo do banco

## Testes
- `cargo check -p job_scheduler`
- `cargo check -p job_worker`


------
https://chatgpt.com/codex/tasks/task_b_68ddc9d7b8d08328a083d4a56c89f68e